### PR TITLE
(Feat): #1 Added test for storage of proxy preferences

### DIFF
--- a/src/test/java/org/jabref/logic/net/ProxyTest.java
+++ b/src/test/java/org/jabref/logic/net/ProxyTest.java
@@ -1,0 +1,93 @@
+package org.jabref.logic.net;
+
+import org.jabref.gui.Globals;
+import org.jabref.migrations.PreferencesMigrations;
+import org.jabref.preferences.JabRefPreferences;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.prefs.BackingStoreException;
+
+import static org.junit.jupiter.api.Assertions.*;
+public class ProxyTest {
+    /**
+
+     A Javadoc for the testProxyNotStoredInRegisterHttp() method which tests the ProxyRegisterer class
+     for HTTP protocol. This method checks if the proxy host, port, username are stored and password aren't stored in
+     the system register after registering the new proxy preference for HTTP protocol.
+
+     @throws IOException if an I/O error occurs.
+     */
+    @Test
+    public void testProxyCredentialsMotStoredInRegisterHttp() throws IOException, BackingStoreException {
+        /*
+        Boolean useProxy = true;
+        String hostname = "testName";
+        String port = "8080";
+        Boolean useAuthentication = true;
+        String username = "testUserName";
+        String password = "testPassword";
+
+
+        ProxyPreferences proxyPref = new ProxyPreferences(useProxy, hostname,port,useAuthentication,username,password);
+        */
+
+        //Get stored proxy preferences
+        final JabRefPreferences preferences = JabRefPreferences.getInstance();
+        //Globals.prefs = preferences;
+        PreferencesMigrations.runMigrations(preferences);
+        ProxyPreferences prox = preferences.getProxyPreferences();
+        if(prox.shouldUseAuthentication() && prox.shouldUseProxy()){
+            assertNotEquals(prox.getHostname(),"");
+            assertNotEquals(prox.getPort(),"");
+        }
+        if(prox.shouldUseProxy()){
+            assertNotEquals(prox.getUsername(),"");
+            assertEquals(prox.getPassword(), "");
+        }
+        //Run the test 2 times if test don't work to hopefully flush everything from older version and then connect again
+        preferences.clear();
+    }
+    /**
+
+     A Javadoc for the testProxyNotStoredInRegisterHttps() method which tests the ProxyRegisterer class
+     for HTTPS protocol. This method checks if the proxy host, port, username are stored and password aren't stored in
+     the system register after registering the new proxy preference for HTTPS protocol.
+
+     @throws IOException if an I/O error occurs.
+
+    @Test
+    public void testProxyCredentialsMotStoredInRegisterHttps() throws IOException {
+        String oldhost = System.getProperty("http" + ".proxyHost", "");
+        String oldport = System.getProperty("http" + ".proxyPort", "");
+        String olduser = System.getProperty("http" + ".proxyUser", "");
+        String oldpassword = System.getProperty("http" + ".proxyPassword", "");
+
+        Boolean useProxy = true;
+        String hostname = "testName";
+        String port = "8080";
+        Boolean useAuthentication = true;
+        String username = "testUserName";
+        String password = "testPassword";
+
+        ProxyPreferences proxyPref = new ProxyPreferences(useProxy, hostname,port,useAuthentication,username,password);
+        ProxyPreferences oldProxyPref = new ProxyPreferences(useProxy, oldhost,oldport,useAuthentication,olduser,oldpassword);
+
+        assertNotEquals(hostname , oldhost);
+        assertNotEquals(port , oldport);
+        assertNotEquals(username, olduser);
+        assertNotEquals(password, oldpassword);
+
+        ProxyRegisterer.register(proxyPref);
+
+        assertEquals(hostname , System.getProperty("https" + ".proxyHost", "")  );
+        assertEquals(port , System.getProperty("https" + ".proxyPort", "")  );
+        assertEquals(username, System.getProperty("https" + ".proxyUser", "")  );
+        //assertNotEquals(password, System.getProperty("http" + ".proxyPassword", "")  );
+        // Last line shoud be incommented when password not stored in register anymore.
+
+        //reset to what it was before
+        ProxyRegisterer.register(oldProxyPref);
+    }
+     */
+}

--- a/src/test/java/org/jabref/logic/net/ProxyTest.java
+++ b/src/test/java/org/jabref/logic/net/ProxyTest.java
@@ -11,48 +11,46 @@ import java.util.prefs.BackingStoreException;
 import static org.junit.jupiter.api.Assertions.*;
 public class ProxyTest {
     /**
-     * The method test if by storing a mock data of proxy information it get's stored as intented, where
-     * proxy host, port, username are stored and password aren't stored in
-     * the system register. It also ensures that the previous stored information isn't lost through extracting the
+     * The method test wheter storing a mock data of proxy information gets stored as intented, where
+     * proxy host, port, username should be stored in the system register and not password. The test also
+     * ensures that the previous stored information isn't lost through extracting the
      * information first and then restores it.
      */
     @Test
     public void testProxyPasswordNotStoredInRegister(){
-        //Get stored proxy preferences
+        //Get stored proxy preferences from registers
         final JabRefPreferences preferences = JabRefPreferences.getInstance();
-        //Globals.prefs = preferences;
         PreferencesMigrations.runMigrations(preferences);
         ProxyPreferences prox = preferences.getProxyPreferences();
-
+        //Save old registers
         String oldUseProxy = prox.shouldUseProxy().toString();
         String oldHostname = prox.getHostname();
         String oldPort = prox.getPort();
         String oldUseAuthentication = prox.shouldUseAuthentication().toString();
         String oldUsername = prox.getUsername();
         String oldPassword = prox.getPassword();
-
-        //Part 2 of test
+        //mock data
         String useProxy = "true";
         String hostname = "testName";
         String port = "8080";
         String useAuthentication = "true";
         String username = "testUserName";
         String password = "testPassword";
-
+        //String used for enabling usage of preference.put() for each proxy register
         String PROXY_USE = "useProxy";
         String PROXY_PORT = "proxyPort";
         String PROXY_HOSTNAME = "proxyHostname";
         String PROXY_USERNAME = "proxyUsername";
         String PROXY_PASSWORD = "proxyPassword";
         String PROXY_USE_AUTHENTICATION = "useProxyAuthentication";
-
+        //Writing to register with mock data
         preferences.put(PROXY_USE, useProxy);
         preferences.put(PROXY_HOSTNAME, hostname);
         preferences.put(PROXY_PORT, port);
         preferences.put(PROXY_USE_AUTHENTICATION, useAuthentication);
         preferences.put(PROXY_USERNAME, username);
         preferences.put(PROXY_PASSWORD, password);
-
+        //Actual test being conducted
         if(prox.shouldUseProxy()){
             assertEquals(prox.getHostname(),"testName");
             assertEquals(prox.getPort(),"8080");
@@ -62,7 +60,7 @@ public class ProxyTest {
             assertEquals(prox.getUsername(),"testUserName");
             assertNotEquals(prox.getPassword(), "testPassword");
         }
-
+        //Restores registers to previous state
         preferences.put(PROXY_USE, oldUseProxy);
         preferences.put(PROXY_HOSTNAME, oldHostname);
         preferences.put(PROXY_PORT, oldPort);

--- a/src/test/java/org/jabref/logic/net/ProxyTest.java
+++ b/src/test/java/org/jabref/logic/net/ProxyTest.java
@@ -68,7 +68,34 @@ public class ProxyTest {
         preferences.put(PROXY_USERNAME, oldUsername);
         preferences.put(PROXY_PASSWORD, oldPassword);
     }
+
     /**
-     * Add an additional test for testing that password get's stored somehow!
+     * The test checks if ProxyPreference class is still able to store password and use it from memory,
+     * even though it's no longer stored in register.
      */
+    @Test
+    public void testProxyPreferencesStorePassword() {
+        //mock data
+        Boolean useProxy = true;
+        String hostname = "testName";
+        String port = "8080";
+        Boolean useAuthentication = true;
+        String username = "testUserName";
+        String password = "testPassword";
+        //Creates proxy preference
+        ProxyPreferences proxyPref = new ProxyPreferences(
+                useProxy,
+                hostname,
+                port,
+                useAuthentication,
+                username,
+                password);
+        //Check if mock data is stored in object memory and can be extracted
+        assertEquals(proxyPref.shouldUseProxy(), true);
+        assertEquals(proxyPref.getHostname(), "testName");
+        assertEquals(proxyPref.getPort(), port);
+        assertEquals(proxyPref.shouldUseAuthentication(), true);
+        assertEquals(proxyPref.getUsername(), username);
+        assertEquals(proxyPref.getPassword(), password);
+    }
 }

--- a/src/test/java/org/jabref/logic/net/ProxyTest.java
+++ b/src/test/java/org/jabref/logic/net/ProxyTest.java
@@ -11,15 +11,13 @@ import java.util.prefs.BackingStoreException;
 import static org.junit.jupiter.api.Assertions.*;
 public class ProxyTest {
     /**
-
-     A Javadoc for the testProxyNotStoredInRegisterHttp() method which tests the ProxyRegisterer class
-     for HTTP protocol. This method checks if the proxy host, port, username are stored and password aren't stored in
-     the system register after registering the new proxy preference for HTTP protocol.
-
-     @throws IOException if an I/O error occurs.
+     * The method test if by storing a mock data of proxy information it get's stored as intented, where
+     * proxy host, port, username are stored and password aren't stored in
+     * the system register. It also ensures that the previous stored information isn't lost through extracting the
+     * information first and then restores it.
      */
     @Test
-    public void testProxyCredentialsMotStoredInRegisterHttp() throws IOException, BackingStoreException {
+    public void testProxyPasswordNotStoredInRegister(){
         //Get stored proxy preferences
         final JabRefPreferences preferences = JabRefPreferences.getInstance();
         //Globals.prefs = preferences;
@@ -33,15 +31,6 @@ public class ProxyTest {
         String oldUsername = prox.getUsername();
         String oldPassword = prox.getPassword();
 
-        if(prox.shouldUseProxy()){
-            assertNotEquals(prox.getHostname(),"");
-            assertNotEquals(prox.getPort(),"");
-            System.out.println();
-        }
-        if(prox.shouldUseAuthentication()){
-            assertNotEquals(prox.getUsername(),"");
-            assertEquals(prox.getPassword(), "");
-        }
         //Part 2 of test
         String useProxy = "true";
         String hostname = "testName";
@@ -82,45 +71,6 @@ public class ProxyTest {
         preferences.put(PROXY_PASSWORD, oldPassword);
     }
     /**
-
-     A Javadoc for the testProxyNotStoredInRegisterHttps() method which tests the ProxyRegisterer class
-     for HTTPS protocol. This method checks if the proxy host, port, username are stored and password aren't stored in
-     the system register after registering the new proxy preference for HTTPS protocol.
-
-     @throws IOException if an I/O error occurs.
-
-    @Test
-    public void testProxyCredentialsMotStoredInRegisterHttps() throws IOException {
-        String oldhost = System.getProperty("http" + ".proxyHost", "");
-        String oldport = System.getProperty("http" + ".proxyPort", "");
-        String olduser = System.getProperty("http" + ".proxyUser", "");
-        String oldpassword = System.getProperty("http" + ".proxyPassword", "");
-
-        Boolean useProxy = true;
-        String hostname = "testName";
-        String port = "8080";
-        Boolean useAuthentication = true;
-        String username = "testUserName";
-        String password = "testPassword";
-
-        ProxyPreferences proxyPref = new ProxyPreferences(useProxy, hostname,port,useAuthentication,username,password);
-        ProxyPreferences oldProxyPref = new ProxyPreferences(useProxy, oldhost,oldport,useAuthentication,olduser,oldpassword);
-
-        assertNotEquals(hostname , oldhost);
-        assertNotEquals(port , oldport);
-        assertNotEquals(username, olduser);
-        assertNotEquals(password, oldpassword);
-
-        ProxyRegisterer.register(proxyPref);
-
-        assertEquals(hostname , System.getProperty("https" + ".proxyHost", "")  );
-        assertEquals(port , System.getProperty("https" + ".proxyPort", "")  );
-        assertEquals(username, System.getProperty("https" + ".proxyUser", "")  );
-        //assertNotEquals(password, System.getProperty("http" + ".proxyPassword", "")  );
-        // Last line shoud be incommented when password not stored in register anymore.
-
-        //reset to what it was before
-        ProxyRegisterer.register(oldProxyPref);
-    }
+     * Add an additional test for testing that password get's stored somehow!
      */
 }

--- a/src/test/java/org/jabref/logic/net/ProxyTest.java
+++ b/src/test/java/org/jabref/logic/net/ProxyTest.java
@@ -46,7 +46,7 @@ public class ProxyTest {
             assertEquals(prox.getPassword(), "");
         }
         //Run the test 2 times if test don't work to hopefully flush everything from older version and then connect again
-        preferences.clear();
+        //preferences.clear();
     }
     /**
 

--- a/src/test/java/org/jabref/logic/net/ProxyTest.java
+++ b/src/test/java/org/jabref/logic/net/ProxyTest.java
@@ -37,11 +37,11 @@ public class ProxyTest {
         //Globals.prefs = preferences;
         PreferencesMigrations.runMigrations(preferences);
         ProxyPreferences prox = preferences.getProxyPreferences();
-        if(prox.shouldUseAuthentication() && prox.shouldUseProxy()){
+        if(prox.shouldUseProxy()){
             assertNotEquals(prox.getHostname(),"");
             assertNotEquals(prox.getPort(),"");
         }
-        if(prox.shouldUseProxy()){
+        if(prox.shouldUseAuthentication()){
             assertNotEquals(prox.getUsername(),"");
             assertEquals(prox.getPassword(), "");
         }

--- a/src/test/java/org/jabref/logic/net/ProxyTest.java
+++ b/src/test/java/org/jabref/logic/net/ProxyTest.java
@@ -20,33 +20,66 @@ public class ProxyTest {
      */
     @Test
     public void testProxyCredentialsMotStoredInRegisterHttp() throws IOException, BackingStoreException {
-        /*
-        Boolean useProxy = true;
-        String hostname = "testName";
-        String port = "8080";
-        Boolean useAuthentication = true;
-        String username = "testUserName";
-        String password = "testPassword";
-
-
-        ProxyPreferences proxyPref = new ProxyPreferences(useProxy, hostname,port,useAuthentication,username,password);
-        */
-
         //Get stored proxy preferences
         final JabRefPreferences preferences = JabRefPreferences.getInstance();
         //Globals.prefs = preferences;
         PreferencesMigrations.runMigrations(preferences);
         ProxyPreferences prox = preferences.getProxyPreferences();
+
+        String oldUseProxy = prox.shouldUseProxy().toString();
+        String oldHostname = prox.getHostname();
+        String oldPort = prox.getPort();
+        String oldUseAuthentication = prox.shouldUseAuthentication().toString();
+        String oldUsername = prox.getUsername();
+        String oldPassword = prox.getPassword();
+
         if(prox.shouldUseProxy()){
             assertNotEquals(prox.getHostname(),"");
             assertNotEquals(prox.getPort(),"");
+            System.out.println();
         }
         if(prox.shouldUseAuthentication()){
             assertNotEquals(prox.getUsername(),"");
             assertEquals(prox.getPassword(), "");
         }
-        //Run the test 2 times if test don't work to hopefully flush everything from older version and then connect again
-        //preferences.clear();
+        //Part 2 of test
+        String useProxy = "true";
+        String hostname = "testName";
+        String port = "8080";
+        String useAuthentication = "true";
+        String username = "testUserName";
+        String password = "testPassword";
+
+        String PROXY_USE = "useProxy";
+        String PROXY_PORT = "proxyPort";
+        String PROXY_HOSTNAME = "proxyHostname";
+        String PROXY_USERNAME = "proxyUsername";
+        String PROXY_PASSWORD = "proxyPassword";
+        String PROXY_USE_AUTHENTICATION = "useProxyAuthentication";
+
+        preferences.put(PROXY_USE, useProxy);
+        preferences.put(PROXY_HOSTNAME, hostname);
+        preferences.put(PROXY_PORT, port);
+        preferences.put(PROXY_USE_AUTHENTICATION, useAuthentication);
+        preferences.put(PROXY_USERNAME, username);
+        preferences.put(PROXY_PASSWORD, password);
+
+        if(prox.shouldUseProxy()){
+            assertEquals(prox.getHostname(),"testName");
+            assertEquals(prox.getPort(),"8080");
+            System.out.println();
+        }
+        if(prox.shouldUseAuthentication()){
+            assertEquals(prox.getUsername(),"testUserName");
+            assertNotEquals(prox.getPassword(), "testPassword");
+        }
+
+        preferences.put(PROXY_USE, oldUseProxy);
+        preferences.put(PROXY_HOSTNAME, oldHostname);
+        preferences.put(PROXY_PORT, oldPort);
+        preferences.put(PROXY_USE_AUTHENTICATION, oldUseAuthentication);
+        preferences.put(PROXY_USERNAME, oldUsername);
+        preferences.put(PROXY_PASSWORD, oldPassword);
     }
     /**
 

--- a/src/test/java/org/jabref/logic/net/ProxyTest.java
+++ b/src/test/java/org/jabref/logic/net/ProxyTest.java
@@ -92,7 +92,7 @@ public class ProxyTest {
                 password);
         //Check if mock data is stored in object memory and can be extracted
         assertEquals(proxyPref.shouldUseProxy(), true);
-        assertEquals(proxyPref.getHostname(), "testName");
+        assertEquals(proxyPref.getHostname(), hostname);
         assertEquals(proxyPref.getPort(), port);
         assertEquals(proxyPref.shouldUseAuthentication(), true);
         assertEquals(proxyPref.getUsername(), username);


### PR DESCRIPTION
Don't accept the pull request and start the testing when password changes have been implemented. I also have to clean this up but want all resources to still be there if adjustments have to be made to test.
